### PR TITLE
Disable TouchBoost and Further Code Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ bullhead/formatted/silverfish_v2.sh
 bullhead/formatted/stable7122015.sh
 bullhead/formatted/maddog.sh
 bullhead/formatted/stable_v2.sh
+angler/formatted/ghostpepper.sh
+angler/formatted/stable_v2.sh

--- a/angler/ghostpepper.sh
+++ b/angler/ghostpepper.sh
@@ -1,22 +1,23 @@
+#Script created by Alcolawl - 1/06/2016 - Please give credit when using this in your work!
 echo ----------------------------------------------------
 echo Applying 'GhostPepper' Interactive Governor Settings
 echo ----------------------------------------------------
 
 #Apply settings to LITTLE cluster
 echo Applying settings to LITTLE cluster
-#Temporarily change permissions to governor files for the little cluster to enable Interactive governor
+#Temporarily change permissions to governor files for the LITTLE cluster to enable Interactive governor
 chmod 644 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu1/online
+echo 1 > /sys/devices/system/cpu/cpu1/online								#Online Core 1
 chmod 644 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu2/online
+echo 1 > /sys/devices/system/cpu/cpu2/online								#Online Core 2
 chmod 644 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu3/online
+echo 1 > /sys/devices/system/cpu/cpu3/online								#Online Core 3
 chmod 644 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
@@ -33,12 +34,12 @@ echo 0 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/boostpulse_duration
 
 #Apply settings to Big cluster
 echo Applying settings to Big cluster
-#Temporarily change permissions to governor files for the little cluster to enable Interactive governor
-echo 1 > /sys/devices/system/cpu/cpu4/online
+#Temporarily change permissions to governor files for the Big cluster to enable Interactive governor
+echo 1 > /sys/devices/system/cpu/cpu4/online								#Online Core 4
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu5/online
+echo 1 > /sys/devices/system/cpu/cpu5/online								#Online Core 5
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
@@ -48,17 +49,18 @@ chmod 444 /sys/devices/system/cpu/cpu6/cpufreq/scaling_governor
 chmod 644 /sys/devices/system/cpu/cpu7/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu7/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu7/cpufreq/scaling_governor
+#Temporarily change permissions to governor files for the Big cluster to lower minimum frequency to 384MHz
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq			#Core 4 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq			#Core 5 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
 chmod 644 /sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq			#Core 6 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq
 chmod 644 /sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq			#Core 7 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq
 #Tweak Interactive Governor
 echo 24 480000:16 633600:29 768000:40 864000:52 960000:63 1248000:71 1344000:80 1440000:88 1536000:94 1632000:97 1728000:98 1824000:99 1948000:100 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads
@@ -76,6 +78,9 @@ echo Enabling Input Boost at 672MHz for the LITTLE cluster
 echo 0:672000 1:672000 2:672000 3:672000 4:0 5:0 6:0 7:0 > /sys/module/cpu_boost/parameters/input_boost_freq
 echo 0 > /sys/module/cpu_boost/parameters/boost_ms
 echo 40 > /sys/module/cpu_boost/parameters/input_boost_ms
+#Disable TouchBoost
+echo Disabling TouchBoost
+echo 0 > /sys/module/msm_performance/parameters/touchboost
 echo ----------------------------------------------------
 echo Settings Successfully Applied! You may now tweak them further in ElementalX Kernel Manager
 echo ----------------------------------------------------

--- a/angler/stable_v2.sh
+++ b/angler/stable_v2.sh
@@ -1,22 +1,23 @@
+#Script created by Alcolawl - 1/06/2016 - Please give credit when using this in your work!
 echo ----------------------------------------------------
 echo Applying Stable v2.0 Interactive Governor Settings
 echo ----------------------------------------------------
 
 #Apply settings to LITTLE cluster
 echo Applying settings to LITTLE cluster
-#Temporarily change permissions to governor files for the little cluster to enable Interactive governor
+#Temporarily change permissions to governor files for the LITTLE cluster to enable Interactive governor
 chmod 644 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu1/online
+echo 1 > /sys/devices/system/cpu/cpu1/online								#Online Core 1
 chmod 644 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu2/online
+echo 1 > /sys/devices/system/cpu/cpu2/online								#Online Core 2
 chmod 644 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu3/online
+echo 1 > /sys/devices/system/cpu/cpu3/online								#Online Core 3
 chmod 644 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
@@ -33,12 +34,12 @@ echo 0 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/boostpulse_duration
 
 #Apply settings to Big cluster
 echo Applying settings to Big cluster
-#Temporarily change permissions to governor files for the little cluster to enable Interactive governor
-echo 1 > /sys/devices/system/cpu/cpu4/online
+#Temporarily change permissions to governor files for the Big cluster to enable Interactive governor
+echo 1 > /sys/devices/system/cpu/cpu4/online								#Online Core 4
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu5/online
+echo 1 > /sys/devices/system/cpu/cpu5/online								#Online Core 5
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
@@ -48,17 +49,18 @@ chmod 444 /sys/devices/system/cpu/cpu6/cpufreq/scaling_governor
 chmod 644 /sys/devices/system/cpu/cpu7/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu7/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu7/cpufreq/scaling_governor
+#Temporarily change permissions to governor files for the Big cluster to lower minimum frequency to 384MHz
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq			#Core 4 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq			#Core 5 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
 chmod 644 /sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq			#Core 6 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq
 chmod 644 /sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq			#Core 7 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq
 #Tweak Interactive Governor
 echo 72 480000:68 633000:74 768000:80 864000:81 960000:69 1248000:84 1344000:84 1440000:84 1536000:85 1632000:85 1728000:85 1824000:84 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads
@@ -76,6 +78,9 @@ echo Disabling Input Boost
 echo 0:0 1:0 2:0 3:0 4:0 5:0 6:0 7:0 > /sys/module/cpu_boost/parameters/input_boost_freq
 echo 0 > /sys/module/cpu_boost/parameters/boost_ms
 echo 0 > /sys/module/cpu_boost/parameters/input_boost_ms
+#Disable TouchBoost
+echo Disabling TouchBoost
+echo 0 > /sys/module/msm_performance/parameters/touchboost
 echo ----------------------------------------------------
 echo Settings Successfully Applied! You may now tweak them further in ElementalX Kernel Manager
 echo ----------------------------------------------------

--- a/bullhead/ghostpepper.sh
+++ b/bullhead/ghostpepper.sh
@@ -1,22 +1,23 @@
+#Script created by Alcolawl - 1/06/2016 - Please give credit when using this in your work!
 echo ----------------------------------------------------
 echo Applying 'GhostPepper' Interactive Governor Settings
 echo ----------------------------------------------------
 
 #Apply settings to LITTLE cluster
 echo Applying settings to LITTLE cluster
-#Temporarily change permissions to governor files for the little cluster to enable Interactive governor
+#Temporarily change permissions to governor files for the LITTLE cluster to enable Interactive governor
 chmod 644 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu1/online
+echo 1 > /sys/devices/system/cpu/cpu1/online								#Online Core 1
 chmod 644 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu2/online
+echo 1 > /sys/devices/system/cpu/cpu2/online								#Online Core 2
 chmod 644 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu3/online
+echo 1 > /sys/devices/system/cpu/cpu3/online								#Online Core 3
 chmod 644 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
@@ -32,20 +33,21 @@ echo 0 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/max_freq_hysteresis
 
 #Apply settings to Big cluster
 echo Applying settings to Big cluster
-#Temporarily change permissions to governor files for the little cluster to enable Interactive governor
-echo 1 > /sys/devices/system/cpu/cpu4/online
+#Temporarily change permissions to governor files for the Big cluster to enable Interactive governor
+echo 1 > /sys/devices/system/cpu/cpu4/online								#Online Core 4
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu5/online
+echo 1 > /sys/devices/system/cpu/cpu5/online								#Online Core 5
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
+#Temporarily change permissions to governor files for the Big cluster to lower minimum frequency to 384MHz
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq			#Core 4 Minimum Frequency = 384MHz			
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq			#Core 5 Minimum Frequency = 384MHz	
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
 #Tweak Interactive Governor
 echo 24 480000:17 633600:31 768000:43 864000:56 960000:79 1248000:76 1344000:85 1440000:92 1536000:95 1632000:98 1689600:99 1824000:100 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads
@@ -62,6 +64,9 @@ echo Enabling Input Boost at 672MHz for the LITTLE cluster
 echo 0:672000 1:672000 2:672000 3:672000 4:0 5:0 > /sys/module/cpu_boost/parameters/input_boost_freq
 echo 0 > /sys/module/cpu_boost/parameters/boost_ms
 echo 40 > /sys/module/cpu_boost/parameters/input_boost_ms
+#Disable TouchBoost
+echo Disabling TouchBoost
+echo 0 > /sys/module/msm_performance/parameters/touchboost
 echo ----------------------------------------------------
 echo Settings Successfully Applied! You may now tweak them further in ElementalX Kernel Manager
 echo ----------------------------------------------------

--- a/bullhead/stable_v2.sh
+++ b/bullhead/stable_v2.sh
@@ -1,22 +1,23 @@
+#Script created by Alcolawl - 1/06/2016 - Please give credit when using this in your work!
 echo ----------------------------------------------------
 echo Applying Stable v2.0 Interactive Governor Settings
 echo ----------------------------------------------------
 
 #Apply settings to LITTLE cluster
 echo Applying settings to LITTLE cluster
-#Temporarily change permissions to governor files for the little cluster to enable Interactive governor
+#Temporarily change permissions to governor files for the LITTLE cluster to enable Interactive governor
 chmod 644 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu1/online
+echo 1 > /sys/devices/system/cpu/cpu1/online								#Online Core 1
 chmod 644 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu2/online
+echo 1 > /sys/devices/system/cpu/cpu2/online								#Online Core 2
 chmod 644 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu3/online
+echo 1 > /sys/devices/system/cpu/cpu3/online								#Online Core 3
 chmod 644 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
@@ -33,20 +34,21 @@ echo 0 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/boostpulse_duration
 
 #Apply settings to Big cluster
 echo Applying settings to Big cluster
-#Temporarily change permissions to governor files for the little cluster to enable Interactive governor
-echo 1 > /sys/devices/system/cpu/cpu4/online
+#Temporarily change permissions to governor files for the Big cluster to enable Interactive governor
+echo 1 > /sys/devices/system/cpu/cpu4/online								#Online Core 4
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu5/online
+echo 1 > /sys/devices/system/cpu/cpu5/online								#Online Core 5
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
+#Temporarily change permissions to governor files for the Big cluster to lower minimum frequency to 384MHz
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq			#Core 4 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq			#Core 5 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
 #Tweak Interactive Governor
 echo 72 480000:68 633000:74 768000:80 864000:81 960000:69 1248000:83 1344000:84 1440000:84 1536000:84 1632000:86 1689000:83 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads
@@ -64,6 +66,9 @@ echo Disabling Input Boost
 echo 0:0 1:0 2:0 3:0 4:0 5:0 > /sys/module/cpu_boost/parameters/input_boost_freq
 echo 0 > /sys/module/cpu_boost/parameters/boost_ms
 echo 0 > /sys/module/cpu_boost/parameters/input_boost_ms
+#Disable TouchBoost
+echo Disabling TouchBoost
+echo 0 > /sys/module/msm_performance/parameters/touchboost
 echo ----------------------------------------------------
 echo Settings Successfully Applied! You may now tweak them further in ElementalX Kernel Manager
 echo ----------------------------------------------------


### PR DESCRIPTION
Scripts now disable TouchBoost by default. Code is also now better
documented
