### PR TITLE
Disable Aggressive CPU Thermal Hotplugging

### DIFF
--- a/angler/ghostpepper.sh
+++ b/angler/ghostpepper.sh
@@ -81,6 +81,10 @@ echo 40 > /sys/module/cpu_boost/parameters/input_boost_ms
 #Disable TouchBoost
 echo Disabling TouchBoost
 echo 0 > /sys/module/msm_performance/parameters/touchboost
+#Disable Core Control and Enable Thermal Throttling allowing for longer sustained performance
+echo Disabling Aggressive CPU Thermal Throttling
+echo 0 > /sys/module/msm_thermal/core_control/enabled
+echo Y > /sys/module/msm_thermal/parameters/enabled
 echo ----------------------------------------------------
 echo Settings Successfully Applied! You may now tweak them further in ElementalX Kernel Manager
 echo ----------------------------------------------------

--- a/angler/stable_v2.sh
+++ b/angler/stable_v2.sh
@@ -81,6 +81,10 @@ echo 0 > /sys/module/cpu_boost/parameters/input_boost_ms
 #Disable TouchBoost
 echo Disabling TouchBoost
 echo 0 > /sys/module/msm_performance/parameters/touchboost
+#Disable Core Control and Enable Thermal Throttling allowing for longer sustained performance
+echo Disabling Aggressive CPU Thermal Throttling
+echo 0 > /sys/module/msm_thermal/core_control/enabled
+echo Y > /sys/module/msm_thermal/parameters/enabled
 echo ----------------------------------------------------
 echo Settings Successfully Applied! You may now tweak them further in ElementalX Kernel Manager
 echo ----------------------------------------------------

--- a/bullhead/ghostpepper.sh
+++ b/bullhead/ghostpepper.sh
@@ -67,6 +67,10 @@ echo 40 > /sys/module/cpu_boost/parameters/input_boost_ms
 #Disable TouchBoost
 echo Disabling TouchBoost
 echo 0 > /sys/module/msm_performance/parameters/touchboost
+#Disable Core Control and Enable Thermal Throttling allowing for longer sustained performance
+echo Disabling Aggressive CPU Thermal Throttling
+echo 0 > /sys/module/msm_thermal/core_control/enabled
+echo Y > /sys/module/msm_thermal/parameters/enabled
 echo ----------------------------------------------------
 echo Settings Successfully Applied! You may now tweak them further in ElementalX Kernel Manager
 echo ----------------------------------------------------

--- a/bullhead/maddog.sh
+++ b/bullhead/maddog.sh
@@ -1,22 +1,27 @@
+#Script created by Alcolawl - 1/06/2016 - Please give credit when using this in your work!
 echo ----------------------------------------------------
 echo Applying 'MadDog' Interactive Governor Settings
 echo ----------------------------------------------------
 
+#Apply settings to LITTLE cluster
 echo Applying settings to LITTLE cluster
+#Temporarily change permissions to governor files for the LITTLE cluster to enable Interactive governor
 chmod 644 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+echo 1 > /sys/devices/system/cpu/cpu1/online								#Online Core 1
 chmod 644 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu2/online
+echo 1 > /sys/devices/system/cpu/cpu2/online								#Online Core 2
 chmod 644 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu3/online
+echo 1 > /sys/devices/system/cpu/cpu3/online								#Online Core 3
 chmod 644 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor
+#Tweak Interactive Governor
 echo 82 460800:69 600000:80 672000:76 787200:81 864000:81 960000:69 1248000:78 1440000:87 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads
 echo -1 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_slack
 echo 672000 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq
@@ -27,21 +32,25 @@ echo 82 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/go_hispeed_load
 echo 0 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/min_sample_time
 echo 0 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/max_freq_hysteresis
 
+#Apply settings to Big cluster
 echo Applying settings to Big cluster
+#Temporarily change permissions to governor files for the Big cluster to enable Interactive governor
+echo 1 > /sys/devices/system/cpu/cpu4/online								#Online Core 4
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor
+echo 1 > /sys/devices/system/cpu/cpu5/online								#Online Core 5
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor
-echo 1 > /sys/devices/system/cpu/cpu5/online
+#Temporarily change permissions to governor files for the Big cluster to lower minimum frequency to 384MHz
 chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq			#Core 4 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
-echo 1 > /sys/devices/system/cpu/cpu1/online
 chmod 644 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
-echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
+echo 384000 > /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq			#Core 5 Minimum Frequency = 384MHz
 chmod 444 /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq
+#Tweak Interactive Governor
 echo 82 480000:68 633600:74 768000:80 864000:81 960000:69 1248000:83 1344000:84 1440000:84 1536000:84 1632000:86 1689600:83 1824000:87 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads
 echo -1 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_slack
 echo 633000 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/hispeed_freq
@@ -52,10 +61,18 @@ echo 72 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/go_hispeed_load
 echo 0 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/min_sample_time
 echo 0 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/max_freq_hysteresis
 
+#Disable Input Boost
 echo Disabling Input Boost
 echo 0:0 1:0 2:0 3:0 4:0 5:0 > /sys/module/cpu_boost/parameters/input_boost_freq
 echo 0 > /sys/module/cpu_boost/parameters/boost_ms
 echo 0 > /sys/module/cpu_boost/parameters/input_boost_ms
+#Disable TouchBoost
+echo Disabling TouchBoost
+echo 0 > /sys/module/msm_performance/parameters/touchboost
+#Disable Core Control and Enable Thermal Throttling allowing for longer sustained performance
+echo Disabling Aggressive CPU Thermal Throttling
+echo 0 > /sys/module/msm_thermal/core_control/enabled
+echo Y > /sys/module/msm_thermal/parameters/enabled
 echo ----------------------------------------------------
 echo Settings Successfully Applied! You may now tweak them further in ElementalX Kernel Manager
 echo ----------------------------------------------------

--- a/bullhead/stable_v2.sh
+++ b/bullhead/stable_v2.sh
@@ -69,6 +69,10 @@ echo 0 > /sys/module/cpu_boost/parameters/input_boost_ms
 #Disable TouchBoost
 echo Disabling TouchBoost
 echo 0 > /sys/module/msm_performance/parameters/touchboost
+#Disable Core Control and Enable Thermal Throttling allowing for longer sustained performance
+echo Disabling Aggressive CPU Thermal Throttling
+echo 0 > /sys/module/msm_thermal/core_control/enabled
+echo Y > /sys/module/msm_thermal/parameters/enabled
 echo ----------------------------------------------------
 echo Settings Successfully Applied! You may now tweak them further in ElementalX Kernel Manager
 echo ----------------------------------------------------


### PR DESCRIPTION
The large cluster of this CPU will shutoff when reaching a certain
temperature. The LITTLE cluster will also throttle at an extremely low
temperature even though it can safely operate at 70 C. Disabling Core
Control and enabling Thermal Throttling allows for sustained performance
under intense loads without risking damage to the device.
