### PR TITLE
URGENT - Revert target_loads to original bullhead values

### DIFF
--- a/angler/butterfly.sh
+++ b/angler/butterfly.sh
@@ -1,4 +1,4 @@
-#Script created by Alcolawl - 1/10/2016 - Please give credit when using this in your work!
+#Script created by Alcolawl - 1/11/2016 - Please give credit when using this in your work!
 echo ----------------------------------------------------
 echo Applying 'ButterFly' Interactive Governor Settings
 echo ----------------------------------------------------
@@ -14,7 +14,7 @@ chmod 644 /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
 echo 384000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq			#Core 0-3 Minimum Frequency = 384MHz			
 chmod 444 /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
 #Tweak Interactive Governor
-echo 70 460800:58 600000:82 672000:72 787200:92 864000:83 960000:99 1248000:75 1440000:70 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads
+echo 70 460800:58 600000:82 672000:72 787200:92 864000:83 960000:99 1248000:75 1478000:70 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads
 echo -1 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_slack
 echo 1440000 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq
 echo 20000 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate

--- a/angler/ghostpepper_v1.1.sh
+++ b/angler/ghostpepper_v1.1.sh
@@ -1,4 +1,4 @@
-#Script created by Alcolawl - 1/10/2016 - Please give credit when using this in your work!
+#Script created by Alcolawl - 1/11/2016 - Please give credit when using this in your work!
 echo ----------------------------------------------------
 echo Applying 'GhostPepper' v1.1 Interactive Governor Settings
 echo ----------------------------------------------------
@@ -10,7 +10,7 @@ chmod 644 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 echo interactive > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 #Tweak Interactive Governor
-echo 15 460800:25 600000:43 672000:65 787200:78 864000:92 960000:95 1248000:98 1440000:99 1555200:100 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads
+echo 15 460800:25 600000:43 672000:65 787200:78 864000:92 960000:95 1248000:98 1478000:100  > /sys/devices/system/cpu/cpu0/cpufreq/interactive/target_loads
 echo -1 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_slack
 echo 384000 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/hispeed_freq
 echo 10000 > /sys/devices/system/cpu/cpu0/cpufreq/interactive/timer_rate
@@ -32,7 +32,7 @@ chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
 echo 633600 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq		#Core 4 Minimum Frequency = 633MHz
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
 #Tweak Interactive Governor
-echo 31 768000:43 864000:56 960000:79 1248000:76 1344000:85 1440000:92 1536000:95 1632000:97 1689600:98 1824000:99 1948000:100 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads
+echo 31 768000:43 864000:56 960000:79 1248000:76 1344000:85 1440000:92 1536000:95 1632000:98 1689600:99 1824000:100 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads
 echo -1 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_slack
 echo 633600 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/hispeed_freq
 echo 40000 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_rate

--- a/angler/redhawk_v2.sh
+++ b/angler/redhawk_v2.sh
@@ -12,7 +12,7 @@ chmod 644 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 echo intelliactive > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 chmod 444 /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
 #Tweak IntelliActive Governor
-echo 15 460800:25 600000:43 672000:65 787200:78 864000:92 960000:95 1248000:98 1440000:99 1555200:100 > /sys/devices/system/cpu/cpufreq/intelliactive/target_loads
+echo 15 460800:25 600000:43 672000:65 787200:78 864000:92 960000:95 1248000:98 1478000:100 > /sys/devices/system/cpu/cpufreq/intelliactive/target_loads
 echo -1 > /sys/devices/system/cpu/cpufreq/intelliactive/timer_slack
 echo 384000 > /sys/devices/system/cpu/cpufreq/intelliactive/hispeed_freq
 echo 10000 > /sys/devices/system/cpu/cpufreq/intelliactive/timer_rate
@@ -36,7 +36,7 @@ chmod 644 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
 echo 633600 > /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq			#Core 4 Minimum Frequency = 633MHz
 chmod 444 /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
 #Tweak Interactive Governor
-echo 31 768000:43 864000:56 960000:79 1248000:76 1344000:85 1440000:92 1536000:95 1632000:97 1689600:98 1824000:99 1948000:100 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads
+echo 31 768000:43 864000:56 960000:79 1248000:76 1344000:85 1440000:92 1536000:95 1632000:98 1689600:99 1824000:100 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/target_loads
 echo -1 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_slack
 echo 1344000 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/hispeed_freq
 echo 20000 > /sys/devices/system/cpu/cpu4/cpufreq/interactive/timer_rate


### PR DESCRIPTION
Change target_loads values back to the same values as the Nexus 5X. May
have been causing issue where CPU would stay at maximum frequency.
